### PR TITLE
[JENKINS-54391] Follow up for the initial framework

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,45 @@
+/* Only keep the 10 most recent builds. */
+properties([[$class: 'BuildDiscarderProperty',
+                strategy: [$class: 'LogRotator', numToKeepStr: '10']]])
+
+node {
+    stage('checkout') {
+        deleteDir()
+        checkout scm
+    }
+    
+    stage('shellcheck') {
+        dir('jenkinsfile-runner-test-framework') {
+            global_check_result=0
+            current_directory="${WORKSPACE}/jenkinsfile-runner-test-framework"
+            def incFiles=findFiles(glob: '**/*.inc')
+            incFiles.each{
+                if("${it}".lastIndexOf("/") == -1) {
+                    output_file="${it}.json"
+                } else {
+                    output_file="${it}".substring("${it}".lastIndexOf("/")+1) + ".json"
+                }
+                echo "$output_file"
+                result=sh (script: "docker run -v $current_directory:/mnt koalaman/shellcheck:latest -f json ${it} > $output_file", returnStatus: true)
+                if(result) {
+                    global_check_result++
+                }
+            }
+            if(global_check_result > 0) {
+                echo "One or more scripts have an invalid sintaxis"
+                currentBuild.result = 'UNSTABLE'
+                archiveArtifacts artifacts: '**/*.inc.json'
+            }
+        }
+    }
+
+    stage('testing') {
+        dir('jenkinsfile-runner-test-framework') {
+            result=sh (script: 'make test', returnStatus: true) != 0
+            if(result) {
+                echo "Test failures!"
+                currentBuild.result = 'FAILED'
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,6 @@ node {
                 } else {
                     output_file="${it}".substring("${it}".lastIndexOf("/")+1) + ".json"
                 }
-                echo "$output_file"
                 result=sh (script: "docker run -v $current_directory:/mnt koalaman/shellcheck:latest -f json ${it} > $output_file", returnStatus: true)
                 if(result) {
                     global_check_result++

--- a/init-jfr-test-framework.inc
+++ b/init-jfr-test-framework.inc
@@ -1,9 +1,13 @@
 #!/bin/bash
 set -e
 
-sources=$(dirname "${BASH_SOURCE[0]}")
+root_directory=$(dirname "${BASH_SOURCE[0]}")
+sources="$root_directory/src"
 export DEFAULT_CWP_VERSION="1.5"
 
+# shellcheck source=src/utilities/utils.inc
 . "$sources"/utilities/utils.inc
-. "$sources"/utilities/cwp/custom-war-packager.inc
-. "$sources"/utilities/jfr/jenkinsfile-runner.inc
+# shellcheck source=src/cwp/custom-war-packager.inc
+. "$sources"/cwp/custom-war-packager.inc
+# shellcheck source=src/jfr/jenkinsfile-runner.inc
+. "$sources"/jfr/jenkinsfile-runner.inc

--- a/init-jfr-test-framework.inc
+++ b/init-jfr-test-framework.inc
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+# Path to this source file, stored in BASH_SOURCE
 root_directory=$(dirname "${BASH_SOURCE[0]}")
 sources="$root_directory/src"
 export DEFAULT_CWP_VERSION="1.5"

--- a/init-jfr-test-framework.inc
+++ b/init-jfr-test-framework.inc
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+sources=$(dirname "${BASH_SOURCE[0]}")
+export DEFAULT_CWP_VERSION="1.5"
+
+. "$sources"/utilities/utils.inc
+. "$sources"/utilities/cwp/custom-war-packager.inc
+. "$sources"/utilities/jfr/jenkinsfile-runner.inc

--- a/src/cwp/custom-war-packager.inc
+++ b/src/cwp/custom-war-packager.inc
@@ -22,13 +22,13 @@ download_cwp() {
 
         if [[ $version_to_download == *"SNAPSHOT"* ]]
         then
-            wget -O "$cwp_jar_file" https://repo.jenkins-ci.org/snapshots/io/jenkins/tools/custom-war-packager/custom-war-packager-cli/$version_to_download/custom-war-packager-cli-$version_to_download-jar-with-dependencies.jar
+            wget -O "$cwp_jar_file" https://repo.jenkins-ci.org/snapshots/io/jenkins/tools/custom-war-packager/custom-war-packager-cli/"$version_to_download"/custom-war-packager-cli-"$version_to_download"-jar-with-dependencies.jar
         else
             if [[ $2 == *"rc"* ]]
             then
-                wget -O "$cwp_jar_file" https://repo.jenkins-ci.org/incrementals/io/jenkins/tools/custom-war-packager/custom-war-packager-cli/$version_to_download/custom-war-packager-cli-$version_to_download-jar-with-dependencies.jar
+                wget -O "$cwp_jar_file" https://repo.jenkins-ci.org/incrementals/io/jenkins/tools/custom-war-packager/custom-war-packager-cli/"$version_to_download"/custom-war-packager-cli-"$version_to_download"-jar-with-dependencies.jar
             else
-                wget -O "$cwp_jar_file" https://repo.jenkins-ci.org/releases/io/jenkins/tools/custom-war-packager/custom-war-packager-cli/$version_to_download/custom-war-packager-cli-$version_to_download-jar-with-dependencies.jar
+                wget -O "$cwp_jar_file" https://repo.jenkins-ci.org/releases/io/jenkins/tools/custom-war-packager/custom-war-packager-cli/"$version_to_download"/custom-war-packager-cli-"$version_to_download"-jar-with-dependencies.jar
             fi
         fi
 
@@ -59,7 +59,7 @@ execute_cwp_jar() {
 
     if [ "$#" -gt 3 ]
     then
-        java -jar $2 -configPath $4 -tmpDir "$1/out/tmp/" -version $3
+        java -jar "$2" -configPath "$4" -tmpDir "$1/out/tmp/" -version "$3"
         return 0
     else
         echo "Error. Missing parameters:"
@@ -87,18 +87,19 @@ execute_cwp_jar_and_generate_docker_image() {
         then
             image_tag="$5"
         else
-            if [ -z "${_shunit_test_}" ]
+            # shellcheck disable=SC2154
+            test_name="${_shunit_test_}"
+            if [ -z "$test_name" ]
             then
                 image_tag="jenkins-experimental/jenkinsfile-runner-test"
             else
-                image_tag="jenkins-experimental/${_shunit_test_}"
+                image_tag="jenkins-experimental/$test_name"
             fi
         fi
 
-        result=$(execute_cwp_jar $1 $2 $3 $4)
-        if [ "$?" -eq "0" ]
+        if execute_cwp_jar "$1" "$2" "$3" "$4"
         then
-            docker build -t $image_tag -f "$1/out/tmp/output/Dockerfile" "$1/out/tmp/output/"
+            docker build -t "$image_tag" -f "$1/out/tmp/output/Dockerfile" "$1/out/tmp/output/"
             return 0
         else
             return 1
@@ -126,10 +127,9 @@ download_execute_and_generate_docker_image_with_cwp() {
 
     if [ "$#" -gt 3 ]
     then
-        cwp_jar_file=$(download_cwp $1 $2)
-        if [ "$?" -eq "0" ]
+        cwp_jar_file=$(download_cwp "$1" "$2")
+        if execute_cwp_jar_and_generate_docker_image "$1" "$cwp_jar_file" "$3" "$4" "$5"
         then
-            execute_cwp_jar_and_generate_docker_image "$1" "$cwp_jar_file" "$3" "$4" "$5"
             return 0
         else
             return 1
@@ -179,7 +179,7 @@ generate_docker_image_from_cwp_docker_image() {
 
         docker pull jenkins/custom-war-packager
         docker run --rm -v "$work_directory/tmp":/tmp -v "$1":/sources/packager-config.yml jenkins/custom-war-packager -configPath /sources/packager-config.yml -tmpDir /tmp/app
-        docker build -t $image_tag -f "$work_directory/tmp/app/output/Dockerfile" "$work_directory/tmp/app/output"
+        docker build -t "$image_tag" -f "$work_directory/tmp/app/output/Dockerfile" "$work_directory/tmp/app/output"
         return 0
     else
         echo "Error. Missing parameters:"

--- a/src/cwp/custom-war-packager.inc
+++ b/src/cwp/custom-war-packager.inc
@@ -177,7 +177,6 @@ generate_docker_image_from_cwp_docker_image() {
         mkdir -p "$work_directory"
         mkdir -p "$work_directory/tmp"
 
-        docker pull jenkins/custom-war-packager
         docker run --rm -v "$work_directory/tmp":/tmp -v "$1":/sources/packager-config.yml jenkins/custom-war-packager -configPath /sources/packager-config.yml -tmpDir /tmp/app
         docker build -t "$image_tag" -f "$work_directory/tmp/app/output/Dockerfile" "$work_directory/tmp/app/output"
         return 0

--- a/src/jfr/jenkinsfile-runner.inc
+++ b/src/jfr/jenkinsfile-runner.inc
@@ -11,9 +11,9 @@ run_jfr_docker_image() {
     then
         if [ -z "$JAVA_OPTS" ]
         then
-            docker run --rm -v $2:/workspace/Jenkinsfile $1
+            docker run --rm -v "$2":/workspace/Jenkinsfile "$1"
         else
-            docker run -e JAVA_OPTS="$JAVA_OPTS" --rm -v $2:/workspace/Jenkinsfile $1
+            docker run -e JAVA_OPTS="$JAVA_OPTS" --rm -v "$2":/workspace/Jenkinsfile "$1"
         fi
 
         return 0

--- a/src/utilities/utils.inc
+++ b/src/utilities/utils.inc
@@ -15,7 +15,7 @@ remove_string() {
         to_remove="$2"
         length_to_remove=${#to_remove}
 
-        result=$(echo "$origin" | cut -b $length_to_remove-$origin_length)
+        result=$(echo "$origin" | cut -b "$length_to_remove"-"$origin_length")
 
         echo "$result"
         return 0

--- a/tests/test_resources/test_with_default_tag_using_cwp_docker_image/packager-config.yml
+++ b/tests/test_resources/test_with_default_tag_using_cwp_docker_image/packager-config.yml
@@ -1,0 +1,81 @@
+bundle:
+  groupId: "io.jenkins.tools.custom-war-packager.demo"
+  artifactId: "jenkinsfile-runner"
+  vendor: "Jenkins project"
+  title: "Jenkinsfile Runner demo"
+  description: "Jenkinsfile Runner Docker Image, produced by Custom WAR Packager"
+buildSettings:
+  jenkinsfileRunner:
+    source:
+      groupId: "io.jenkins"
+      artifactId: "jenkinsfile-runner"
+      build:
+        noCache: true
+      source:
+        git: https://github.com/jenkinsci/jenkinsfile-runner.git
+        branch: parent-1.0-beta-4
+    docker:
+      base: "jenkins/jenkins:2.138.2"
+      tag: "jenkins-experimental/jenkinsfile-runner-demo"
+      build: false
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    version: "2.138.2"
+plugins:
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-job"
+    source:
+      version: "2.24"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-cps"
+    source:
+      version: "2.48"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-api"
+    source:
+      version: "2.27"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-step-api"
+    source:
+      version: "2.14"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "pipeline-utility-steps"
+    source:
+      version: "2.1.0"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "cloudbees-folder"
+    source:
+      version: "6.4"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials"
+    source:
+      version: "2.1.11"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "structs"
+    source:
+      version: "1.14"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "scm-api"
+    source:
+      version: "2.2.6"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "ssh-credentials"
+    source:
+      version: "1.12"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials-binding"
+    source:
+      version: "1.16"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-aggregator"
+    source:
+      version: "2.5"
+  - groupId: "io.jenkins"
+    artifactId: "configuration-as-code"
+    source:
+      version: "1.1"
+systemProperties: {
+    jenkins.model.Jenkins.slaveAgentPort: "50000",
+    jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}

--- a/tests/test_resources/test_with_tag_using_cwp_docker_image/Jenkinsfile
+++ b/tests/test_resources/test_with_tag_using_cwp_docker_image/Jenkinsfile
@@ -1,0 +1,9 @@
+
+stage('Read Evergreen YAML') {
+    node {
+        // Discover core version using Pipeline utility steps
+        sh 'wget https://raw.githubusercontent.com/jenkins-infra/evergreen/master/services/essentials.yaml'
+        def essentialsYaml = readYaml(file: "essentials.yaml")
+        echo "Jenkins Evergreen uses the following Core version: ${essentialsYaml.spec.core.version}"
+    }
+}

--- a/tests/test_resources/test_with_tag_using_cwp_docker_image/packager-config.yml
+++ b/tests/test_resources/test_with_tag_using_cwp_docker_image/packager-config.yml
@@ -1,0 +1,81 @@
+bundle:
+  groupId: "io.jenkins.tools.custom-war-packager.demo"
+  artifactId: "jenkinsfile-runner"
+  vendor: "Jenkins project"
+  title: "Jenkinsfile Runner demo"
+  description: "Jenkinsfile Runner Docker Image, produced by Custom WAR Packager"
+buildSettings:
+  jenkinsfileRunner:
+    source:
+      groupId: "io.jenkins"
+      artifactId: "jenkinsfile-runner"
+      build:
+        noCache: true
+      source:
+        git: https://github.com/jenkinsci/jenkinsfile-runner.git
+        branch: parent-1.0-beta-4
+    docker:
+      base: "jenkins/jenkins:2.138.2"
+      tag: "jenkins-experimental/jenkinsfile-runner-demo"
+      build: false
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    version: "2.138.2"
+plugins:
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-job"
+    source:
+      version: "2.24"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-cps"
+    source:
+      version: "2.48"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-api"
+    source:
+      version: "2.27"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-step-api"
+    source:
+      version: "2.14"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "pipeline-utility-steps"
+    source:
+      version: "2.1.0"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "cloudbees-folder"
+    source:
+      version: "6.4"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials"
+    source:
+      version: "2.1.11"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "structs"
+    source:
+      version: "1.14"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "scm-api"
+    source:
+      version: "2.2.6"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "ssh-credentials"
+    source:
+      version: "1.12"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "credentials-binding"
+    source:
+      version: "1.16"
+  - groupId: "org.jenkins-ci.plugins.workflow"
+    artifactId: "workflow-aggregator"
+    source:
+      version: "2.5"
+  - groupId: "io.jenkins"
+    artifactId: "configuration-as-code"
+    source:
+      version: "1.1"
+systemProperties: {
+    jenkins.model.Jenkins.slaveAgentPort: "50000",
+    jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -58,9 +58,9 @@ test_download_cwp_version() {
   assertEquals "Should retrieve exit code 0" "0" "$?"
   assertContains "Should contain the the default version" "$default_cwp_jar" "cwp-cli-$DEFAULT_CWP_VERSION.jar"
 
-  another_cwp_jar=$(download_cwp "$test_framework_directory" "1.5")
+  another_cwp_jar=$(download_cwp "$test_framework_directory" "1.3")
   assertEquals "Should retrieve exit code 0" "0" "$?"
-  assertContains "Should contain the the given version" "$another_cwp_jar" "cwp-cli-1.5.jar"
+  assertContains "Should contain the the given version" "$another_cwp_jar" "cwp-cli-1.3.jar"
 }
 
 test_with_tag_using_cwp_docker_image() {

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -3,20 +3,18 @@ set -e
 
 current_directory=$(pwd)
 test_framework_directory="$current_directory/.."
-sh_unit_directory="$current_directory/.testing/shunit2"
+working_directory="$current_directory/.testing"
+sh_unit_directory="$working_directory/shunit2"
 
 version="256.0-test"
-CWP_version="1.5"
 jenkinsfile_runner_tag="jenkins-experimental/jenkinsfile-runner-test-image"
 
 downloaded_cwp_jar="to_update"
 
-. $test_framework_directory/utilities/utils.inc
-. $test_framework_directory/utilities/cwp/custom-war-packager.inc
-. $test_framework_directory/utilities/jfr/jenkinsfile-runner.inc
+. $test_framework_directory/init-jfr-test-framework.inc
 
 oneTimeSetUp() {
-  downloaded_cwp_jar=$(download_cwp "$test_framework_directory" "$CWP_version")
+  downloaded_cwp_jar=$(download_cwp "$test_framework_directory")
 }
 
 test_with_tag() {
@@ -30,10 +28,57 @@ test_with_tag() {
   assertContains "Should execute the Jenkinsfile successfully" "$result" "Finished: SUCCESS"
 }
 
+test_java_opts() {
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$test_framework_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/test_with_tag/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  assertEquals "Should retrieve exit code 0" "0" "$?"
+  assertContains "Should contain the given tag" "$jfr_tag" "$jenkinsfile_runner_tag"
+
+  result=$(run_jfr_docker_image "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_with_tag/Jenkinsfile")
+  assertEquals "Should retrieve exit code 0" "0" "$?"
+  assertContains "Should execute the Jenkinsfile successfully" "$result" "[Pipeline] End of Pipeline"
+  assertContains "Should execute the Jenkinsfile successfully" "$result" "Finished: SUCCESS"
+
+  export JAVA_OPTS="-Xmx1M -Xms100G"
+  result=$(run_jfr_docker_image "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_with_tag/Jenkinsfile")
+  assertEquals "Should retrieve exit code 0" "0" "$?"
+  assertNotContains "Should not execute the Jenkinsfile successfully" "$result" "[Pipeline] End of Pipeline"
+  assertNotContains "Should not execute the Jenkinsfile successfully" "$result" "Finished: SUCCESS"
+  assertContains "Should execute the Jenkinsfile successfully" "$result" "Initial heap size set to a larger value than the maximum heap size"
+  unset JAVA_OPTS
+}
+
 test_with_default_tag() {
   jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$test_framework_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/test_with_tag/packager-config.yml" | grep 'Successfully tagged')
   assertEquals "Should retrieve exit code 0" "0" "$?"
   assertNotContains "Should not contain the given tag" "$jfr_tag" "$jenkinsfile_runner_tag"
+}
+
+test_download_cwp_version() {
+  default_cwp_jar=$(download_cwp "$test_framework_directory")
+  assertEquals "Should retrieve exit code 0" "0" "$?"
+  assertContains "Should contain the the default version" "$default_cwp_jar" "cwp-cli-$DEFAULT_CWP_VERSION.jar"
+
+  another_cwp_jar=$(download_cwp "$test_framework_directory" "1.5")
+  assertEquals "Should retrieve exit code 0" "0" "$?"
+  assertContains "Should contain the the given version" "$another_cwp_jar" "cwp-cli-1.5.jar"
+}
+
+test_with_tag_using_cwp_docker_image() {
+  jfr_tag=$(generate_docker_image_from_cwp_docker_image "$current_directory/test_resources/test_with_tag_using_cwp_docker_image/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  assertEquals "Should retrieve exit code 0" "0" "$?"
+  assertContains "Should contain the given tag" "$jfr_tag" "$jenkinsfile_runner_tag"
+  
+  result=$(run_jfr_docker_image "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_with_tag_using_cwp_docker_image/Jenkinsfile")
+  assertEquals "Should retrieve exit code 0" "0" "$?"
+  assertContains "Should execute the Jenkinsfile successfully" "$result" "[Pipeline] End of Pipeline"
+  assertContains "Should execute the Jenkinsfile successfully" "$result" "Finished: SUCCESS"
+}
+
+test_with_default_tag_using_cwp_docker_image() {
+  jfr_tag=$(generate_docker_image_from_cwp_docker_image "$current_directory/test_resources/test_with_default_tag_using_cwp_docker_image/packager-config.yml" | grep 'Successfully tagged')
+  assertEquals "Should retrieve exit code 0" "0" "$?"
+  assertNotContains "Should not contain the given tag" "$jfr_tag" "$jenkinsfile_runner_tag"
+  assertContains "Should contain the name of the test" "$jfr_tag" "test_with_default_tag"
 }
 
 . $sh_unit_directory/shunit2

--- a/utilities/cwp/custom-war-packager.inc
+++ b/utilities/cwp/custom-war-packager.inc
@@ -3,25 +3,32 @@ set -e
 
 # function to download the CWP jar
 # $1: Working directory
-# $2: CWP version to use
+# $2: CWP version to use. Optional
 download_cwp() {
 
-    if [ "$#" -gt 1 ]
+    if [ "$#" -ge 1 ]
     then
-        cwp_jar_file="$1/.cwp-build/cwp-cli-$2.jar"
+        if [ "$#" -eq 2 ]
+        then
+            version_to_download="$2"
+        else
+            version_to_download="$DEFAULT_CWP_VERSION"
+        fi
+
+        cwp_jar_file="$1/.cwp-build/cwp-cli-$version_to_download.jar"
 
         rm -rf "$1/.cwp-build"
         mkdir -p "$1/.cwp-build"
 
-        if [[ $2 == *"SNAPSHOT"* ]]
+        if [[ $version_to_download == *"SNAPSHOT"* ]]
         then
-            wget -O "$cwp_jar_file" https://repo.jenkins-ci.org/snapshots/io/jenkins/tools/custom-war-packager/custom-war-packager-cli/$2/custom-war-packager-cli-$2-jar-with-dependencies.jar
+            wget -O "$cwp_jar_file" https://repo.jenkins-ci.org/snapshots/io/jenkins/tools/custom-war-packager/custom-war-packager-cli/$version_to_download/custom-war-packager-cli-$version_to_download-jar-with-dependencies.jar
         else
             if [[ $2 == *"rc"* ]]
             then
-                wget -O "$cwp_jar_file" https://repo.jenkins-ci.org/incrementals/io/jenkins/tools/custom-war-packager/custom-war-packager-cli/$2/custom-war-packager-cli-$2-jar-with-dependencies.jar
+                wget -O "$cwp_jar_file" https://repo.jenkins-ci.org/incrementals/io/jenkins/tools/custom-war-packager/custom-war-packager-cli/$version_to_download/custom-war-packager-cli-$version_to_download-jar-with-dependencies.jar
             else
-                wget -O "$cwp_jar_file" https://repo.jenkins-ci.org/releases/io/jenkins/tools/custom-war-packager/custom-war-packager-cli/$2/custom-war-packager-cli-$2-jar-with-dependencies.jar
+                wget -O "$cwp_jar_file" https://repo.jenkins-ci.org/releases/io/jenkins/tools/custom-war-packager/custom-war-packager-cli/$version_to_download/custom-war-packager-cli-$version_to_download-jar-with-dependencies.jar
             fi
         fi
 
@@ -37,7 +44,7 @@ download_cwp() {
     else
         echo "Error. Missing parameters:"
         echo "   Working directory"
-        echo "   CWP version to use"
+        echo "   (Optional) CWP version to use. ${DEFAULT_CWP_VERSION} by default"
         return 1
     fi
 
@@ -102,13 +109,13 @@ execute_cwp_jar_and_generate_docker_image() {
         echo "   Path to cwp.jar"
         echo "   Jenkins version"
         echo "   Path to packager config file"
-        echo "   Tag for the docker image. 'jenkins-experimental/TEST_NAME' by default or 'jenkins-experimental/jenkinsfile-runner-test' if it is run from a setUp function"
+        echo "   (Optional) Tag for the docker image. 'jenkins-experimental/TEST_NAME' by default or 'jenkins-experimental/jenkinsfile-runner-test' if it is run from a setUp function"
         return 1
     fi
 
 }
 
-# function to generate the docker image using CWP
+# function to generate the docker image using CWP downloading a downloaded jar
 # $1: Working directory
 # $2: CWP version to use
 # $3: Jenkins version
@@ -133,7 +140,51 @@ download_execute_and_generate_docker_image_with_cwp() {
         echo "   Path to cwp.jar"
         echo "   Jenkins version"
         echo "   Path to packager config file"
-        echo "   Tag for the docker image. 'jenkins-experimental/TEST_NAME' by default or 'jenkins-experimental/jenkinsfile-runner-test' if it is run from a setUp function"
+        echo "   (Optional) Tag for the docker image. 'jenkins-experimental/TEST_NAME' by default or 'jenkins-experimental/jenkinsfile-runner-test' if it is run from a setUp function"
+        return 1
+    fi
+
+}
+
+# function to generate the docker image using the CWP docker image
+# $2: Path to packager config file
+# $3: Tag for the docker image. "jenkins-experimental/${TEST_NAME}" by default or
+# "jenkins-experimental/jenkinsfile-runner-test" if it is run from a setUp function
+generate_docker_image_from_cwp_docker_image() {
+
+    if [ "$#" -ge 1 ]
+    then
+        if [ "$#" -eq 2 ]
+        then
+            image_tag="$2"
+        else
+            if [ -z "${_shunit_test_}" ]
+            then
+                image_tag="jenkins-experimental/jenkinsfile-runner-test"
+            else
+                image_tag="jenkins-experimental/${_shunit_test_}"
+            fi
+        fi
+
+        if [ -z "${_shunit_test_}" ]
+        then
+            # In case this function is not invoked from the test but from a setUp/tearDown function
+            work_directory="/tmp/.cwp-docker"
+        else
+            work_directory="/tmp/${_shunit_test_}/.cwp-docker"
+        fi
+
+        mkdir -p "$work_directory"
+        mkdir -p "$work_directory/tmp"
+
+        docker pull jenkins/custom-war-packager
+        docker run --rm -v "$work_directory/tmp":/tmp -v "$1":/sources/packager-config.yml jenkins/custom-war-packager -configPath /sources/packager-config.yml -tmpDir /tmp/app
+        docker build -t $image_tag -f "$work_directory/tmp/app/output/Dockerfile" "$work_directory/tmp/app/output"
+        return 0
+    else
+        echo "Error. Missing parameters:"
+        echo "   Path to packager config file"
+        echo "   (Optional) Tag for the docker image. 'jenkins-experimental/TEST_NAME' by default or 'jenkins-experimental/jenkinsfile-runner-test' if it is run from a setUp function"
         return 1
     fi
 

--- a/utilities/jfr/jenkinsfile-runner.inc
+++ b/utilities/jfr/jenkinsfile-runner.inc
@@ -4,11 +4,18 @@ set -e
 # function to run a docker image
 # $1: tag of the docker image
 # $2: Path to Jenkinsfile
+# $3: Value of JAVA_OPTS
 run_jfr_docker_image() {
 
     if [ "$#" -gt 1 ]
     then
-        docker run --rm -v $2:/workspace/Jenkinsfile $1
+        if [ -z "$JAVA_OPTS" ]
+        then
+            docker run --rm -v $2:/workspace/Jenkinsfile $1
+        else
+            docker run -e JAVA_OPTS="$JAVA_OPTS" --rm -v $2:/workspace/Jenkinsfile $1
+        fi
+
         return 0
     else
         echo "Error. Missing parameters:"


### PR DESCRIPTION
See [JENKINS-54391](https://issues.jenkins-ci.org/browse/JENKINS-54391)

This pull request pretends to be a follow up for #1, covering:
- Add a Jenkinsfile to check at least the syntax of the scripts and run the smoke tests
- Support to pass parameters like Java Options to `docker run`
- Add support to use the CWP docker image, not only a downloaded jar
- Add a CWP version by default, so it’s not necessary to pass it as parameter
- Add a wrapper script so the test-framework has a unique load point