### PR TITLE
Replace stat -c command with more portable du

### DIFF
--- a/src/cwp/custom-war-packager.inc
+++ b/src/cwp/custom-war-packager.inc
@@ -32,7 +32,7 @@ download_cwp() {
             fi
         fi
 
-        downloaded=$(stat -c%s "$cwp_jar_file")
+        downloaded=$(du -k "$cwp_jar_file" | cut -f1)
         if [ "$downloaded" == "0" ]
         then
             echo "CWP jar not found"


### PR DESCRIPTION
This script was using "stat -c%s" to determine if the cwp jar was successfully downloaded.  Unfortunately that command does not work on mac, so I am replacing it with "du -k $filename | cut -f1" which is more portable.
