### PR TITLE
[JENKINS-54391] How to check syntax locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 out
 .cwp-build/
 tests/.testing
+shunit2/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ node {
                 } else {
                     output_file="${it}".substring("${it}".lastIndexOf("/")+1) + ".json"
                 }
-                result=sh (script: "docker run -v $current_directory:/mnt koalaman/shellcheck:latest -f json ${it} > $output_file", returnStatus: true)
+                result=sh (script: "docker run -v $current_directory:/mnt koalaman/shellcheck:stable -f json ${it} > $output_file", returnStatus: true)
                 if(result) {
                     global_check_result++
                 }

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 # Main makefile for the testing framework. It should be executed by the actual project containing the tests
-.PHONY: init
+.PHONY: init verify
 
 init:
 	rm -rf shunit2
+	# avoid any cache of checks/tests
+	rm -rf tests/.testing
+	rm -rf checksyntax/.checksyntax
 	# TODO So far, the released tags do not contains all the macros and functions that
 	# master branch does (assertContains, e.g.). Once a new version containing all 
 	# the functionalyty is released we should clone using --branch

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,8 @@ init:
 
 test:
 	$(MAKE) -C tests
+
+syntax:
+	$(MAKE) -C checksyntax
+
+verify: syntax test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Main makefile for the testing framework. It should be executed by the actual project containing the tests
-.PHONY: init verify
+.PHONY: init
 
 init:
 	rm -rf shunit2

--- a/checksyntax/Makefile
+++ b/checksyntax/Makefile
@@ -1,0 +1,5 @@
+# Makefile to check the syntax of the scripts
+.PHONY: syntax
+
+syntax:
+	$(shell pwd)/check_syntax.sh

--- a/checksyntax/check_syntax.sh
+++ b/checksyntax/check_syntax.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+# Path to this source file
+export parent_directory=$(dirname "$(pwd)")
+export check_directory="$parent_directory/checksyntax/.checksyntax"
+
+process_inc_file() {
+  echo "Checking $1"
+  output_file="$check_directory/${1##*/}.gcc"
+  docker run -v "$parent_directory":/mnt koalaman/shellcheck:stable -f gcc "$1" > "$output_file"
+  result=$(cat "$output_file")
+  if [ -z "$result" ]
+  then
+    rm "$output_file"
+  else
+    echo "$result"
+  fi
+  echo ""
+}
+
+cd "$parent_directory"
+rm -rf "$check_directory"
+mkdir -p "$check_directory"
+
+export -f process_inc_file
+find . -name '*.inc' -exec bash -c 'process_inc_file {}' \;
+
+echo "[INFO] A copy of the results can be found at $check_directory"
+echo ""


### PR DESCRIPTION
Working on #3 I've realised I'm not able to check any new script because the CI environment is not still ready and there is no manual mechanism to check in local environments. With this PR:

#### From jenkinsfile-runner-test-framework directory
- Execute `make verify` to check syntax and to launch tests
- Execute `maken test` to launch tests
- Execute `make syntax` to check syntax

#### From jenkinsfile-runner-test-framework/checksyntax directory
- Execute `make` to check the syntax

The local execution will display on console the result of checking file by file and it will also store the result on disc