### PR TITLE
Allow calls to run_jfr_docker_image to pass JAVA_OPTS

### DIFF
--- a/src/jfr/jenkinsfile-runner.inc
+++ b/src/jfr/jenkinsfile-runner.inc
@@ -9,6 +9,9 @@ run_jfr_docker_image() {
 
     if [ "$#" -gt 1 ]
     then
+        docker run -e JAVA_OPTS="$JAVA_OPTS $3" --rm -v "$2":/workspace/Jenkinsfile "$1"
+    elif [ "$#" -gt 1 ]
+    then
         if [ -z "$JAVA_OPTS" ]
         then
             docker run --rm -v "$2":/workspace/Jenkinsfile "$1"


### PR DESCRIPTION
The comments for this script say that JAVA_OPTS can be passed as an optional 3rd parameter (https://github.com/jenkinsci/jenkinsfile-runner-test-framework/blob/master/src/jfr/jenkinsfile-runner.inc#L7) but the script actually ignores it.  This change will pass any arguments along to the docker run command.

