### PR TITLE
[JENKINS-54391] Polish initialization of framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 out
 .cwp-build/
 tests/.testing
-shunit2/
+checksyntax/.checksyntax/
+.shunit2/

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,14 @@
 .PHONY: init
 
 init:
-	rm -rf shunit2
+	rm -rf .shunit2
 	# avoid any cache of checks/tests
 	rm -rf tests/.testing
 	rm -rf checksyntax/.checksyntax
 	# TODO So far, the released tags do not contains all the macros and functions that
 	# master branch does (assertContains, e.g.). Once a new version containing all 
 	# the functionalyty is released we should clone using --branch
-	git clone --depth 1 https://github.com/kward/shunit2 && cd shunit2 && git checkout abb3ab2fef8c549933e378ae3d12127dfc748e73
+	git clone --depth 1 https://github.com/kward/shunit2 .shunit2 && cd .shunit2 && git checkout abb3ab2fef8c549933e378ae3d12127dfc748e73
 
 test:
 	$(MAKE) -C tests

--- a/init-jfr-test-framework.inc
+++ b/init-jfr-test-framework.inc
@@ -4,7 +4,19 @@ set -e
 # Path to this source file, stored in BASH_SOURCE
 root_directory=$(dirname "${BASH_SOURCE[0]}")
 sources="$root_directory/src"
+sh_unit_directory="$root_directory/tests/.testing/shunit2"
 export DEFAULT_CWP_VERSION="1.5"
+
+if [ ! -d "$sh_unit_directory" ]
+then
+    if [ -z "$1" ] || [ ! -d "$1" ]
+    then
+        echo "[ERROR] shUnit2 has not been properly initialized"
+        exit 1
+    else
+        sh_unit_directory="$1"
+    fi
+fi
 
 # shellcheck source=src/utilities/utils.inc
 . "$sources"/utilities/utils.inc
@@ -14,3 +26,7 @@ export DEFAULT_CWP_VERSION="1.5"
 . "$sources"/cwp/custom-war-packager.inc
 # shellcheck source=src/jfr/jenkinsfile-runner.inc
 . "$sources"/jfr/jenkinsfile-runner.inc
+
+init_framework() {
+    . $sh_unit_directory/shunit2
+}

--- a/init-jfr-test-framework.inc
+++ b/init-jfr-test-framework.inc
@@ -4,7 +4,7 @@ set -e
 # Path to this source file, stored in BASH_SOURCE
 root_directory=$(dirname "${BASH_SOURCE[0]}")
 sources="$root_directory/src"
-sh_unit_directory="$root_directory/tests/.testing/shunit2"
+sh_unit_directory="$root_directory/.shunit2"
 export DEFAULT_CWP_VERSION="1.5"
 
 if [ ! -d "$sh_unit_directory" ]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,10 +2,11 @@
 .PHONY: test
 
 test:
+	rm -rf ../.shunit2
 	rm -rf .testing
 	mkdir -p .testing
 	# TODO So far, the released tags do not contains all the macros and functions that
 	# master branch does (assertContains, e.g.). Once a new version containing all 
 	# the functionalyty is released we should clone using --branch
-	git clone --depth 1 https://github.com/kward/shunit2 .testing/shunit2 && cd .testing/shunit2 && git checkout abb3ab2fef8c549933e378ae3d12127dfc748e73
+	git clone --depth 1 https://github.com/kward/shunit2 ../.shunit2 && cd ../.shunit2 && git checkout abb3ab2fef8c549933e378ae3d12127dfc748e73
 	./tests.sh

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -4,7 +4,6 @@ set -e
 current_directory=$(pwd)
 test_framework_directory="$current_directory/.."
 working_directory="$current_directory/.testing"
-sh_unit_directory="$working_directory/shunit2"
 
 version="256.0-test"
 jenkinsfile_runner_tag="jenkins-experimental/jenkinsfile-runner-test-image"
@@ -88,4 +87,4 @@ test_jenkinsfile_unstable() {
   jenkinsfile_execution_should_be_unstable "$?" "$result"
 }
 
-. $sh_unit_directory/shunit2
+init_framework

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -13,11 +13,11 @@ downloaded_cwp_jar="to_update"
 . $test_framework_directory/init-jfr-test-framework.inc
 
 oneTimeSetUp() {
-  downloaded_cwp_jar=$(download_cwp "$test_framework_directory")
+  downloaded_cwp_jar=$(download_cwp "$working_directory")
 }
 
 test_with_tag() {
-  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$test_framework_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/test_with_tag/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/test_with_tag/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
   execution_should_success "$?" "$jfr_tag" "$jenkinsfile_runner_tag"
   
   result=$(run_jfr_docker_image "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_with_tag/Jenkinsfile")
@@ -25,7 +25,7 @@ test_with_tag() {
 }
 
 test_java_opts() {
-  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$test_framework_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/test_with_tag/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/test_with_tag/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
   execution_should_success "$?" "$jfr_tag" "$jenkinsfile_runner_tag"
 
   result=$(run_jfr_docker_image "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_with_tag/Jenkinsfile")
@@ -41,15 +41,15 @@ test_java_opts() {
 }
 
 test_with_default_tag() {
-  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$test_framework_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/test_with_tag/packager-config.yml" | grep 'Successfully tagged')
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/test_with_tag/packager-config.yml" | grep 'Successfully tagged')
   execution_should_success "$?" "$jfr_tag" "test_with_default_tag"
 }
 
 test_download_cwp_version() {
-  default_cwp_jar=$(download_cwp "$test_framework_directory")
+  default_cwp_jar=$(download_cwp "$working_directory")
   execution_should_success "$?" "$default_cwp_jar" "cwp-cli-$DEFAULT_CWP_VERSION.jar"
 
-  another_cwp_jar=$(download_cwp "$test_framework_directory" "1.3")
+  another_cwp_jar=$(download_cwp "$working_directory" "1.3")
   execution_should_success "$?" "$another_cwp_jar" "cwp-cli-1.3.jar"
 }
 
@@ -67,12 +67,12 @@ test_with_default_tag_using_cwp_docker_image() {
 }
 
 test_failing_docker_image() {
-  result=$(execute_cwp_jar_and_generate_docker_image "$test_framework_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/test_failing_docker_image/packager-config.yml")
+  result=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/test_failing_docker_image/packager-config.yml")
   docker_generation_should_fail "$?" "$result"
 }
 
 test_jenkinsfile_fail() {
-  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$test_framework_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/test_with_tag/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/test_with_tag/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
   execution_should_success "$?" "$jfr_tag" "$jenkinsfile_runner_tag"
 
   result=$(run_jfr_docker_image "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_jenkinsfile_fail/Jenkinsfile")
@@ -80,7 +80,7 @@ test_jenkinsfile_fail() {
 }
 
 test_jenkinsfile_unstable() {
-  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$test_framework_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/test_with_tag/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
+  jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/test_with_tag/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
   execution_should_success "$?" "$jfr_tag" "$jenkinsfile_runner_tag"
 
   result=$(run_jfr_docker_image "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_jenkinsfile_unstable/Jenkinsfile")


### PR DESCRIPTION
This PR pretends to ease a little the initial load of the test framework, so:
* Checks if shUnit2 is downloaded and exit if not
* Provides a function to load shUnit2
* Unify the working directories created at any execution since depending on the goal init or test, the working directory changed