### PR TITLE
[JENKINS-54391] Support for timeouts

### DIFF
--- a/init-jfr-test-framework.inc
+++ b/init-jfr-test-framework.inc
@@ -5,6 +5,7 @@ set -e
 root_directory=$(dirname "${BASH_SOURCE[0]}")
 sources="$root_directory/src"
 sh_unit_directory="$root_directory/.shunit2"
+timeout_test_file="/tmp/with_timeout.sh"
 export DEFAULT_CWP_VERSION="1.5"
 
 if [ ! -d "$sh_unit_directory" ]
@@ -20,6 +21,8 @@ fi
 
 # shellcheck source=src/utilities/utils.inc
 . "$sources"/utilities/utils.inc
+# shellcheck source=src/utilities/timeout.inc
+. "$sources"/utilities/timeout.inc
 # shellcheck source=src/hooks/result.inc
 . "$sources"/hooks/result.inc
 # shellcheck source=src/hooks/workspace.inc
@@ -29,6 +32,34 @@ fi
 # shellcheck source=src/jfr/jenkinsfile-runner.inc
 . "$sources"/jfr/jenkinsfile-runner.inc
 
+
+search_tests() {
+
+    # Extract the lines with test function names, strip of anything besides the
+    # function name, and output everything on a single line.
+    test_regex='^\s*((function test[A-Za-z0-9_-]*)|(test[A-Za-z0-9_-]* *\(\)))'
+    # shellcheck disable=SC2196
+    egrep "${test_regex}" "$0" \
+    |sed 's/^[^A-Za-z0-9_-]*//;s/^function //;s/\([A-Za-z0-9_-]*\).*/\1/g' \
+    |xargs
+
+}
+
+# Override the suite test to execute the tests with timeout if applies
+suite() {
+
+    tests=$(search_tests)
+    for name in ${tests}; do
+        new_test=$(create_test_with_template "$name" "$timeout_test_file")
+        suite_addTest "$new_test"
+    done
+    # shellcheck disable=SC1090
+    . $timeout_test_file
+	
+}
+
 init_framework() {
-    . $sh_unit_directory/shunit2
+    create_test_file "$timeout_test_file"
+	# shellcheck disable=SC1090
+    . "$sh_unit_directory/shunit2"
 }

--- a/src/utilities/timeout.inc
+++ b/src/utilities/timeout.inc
@@ -115,6 +115,6 @@ kill_process_and_subprocess() {
         kill_process_and_subprocess "$subprocess"
     done
     # Kill execution
-    kill "$1" 2> /dev/null 
+    timeout 30 kill "$1" 2> /dev/null 
 
 }

--- a/src/utilities/timeout.inc
+++ b/src/utilities/timeout.inc
@@ -1,0 +1,120 @@
+#!/bin/bash
+set -e
+
+# 5 minutes by default
+default_timeout=300
+export TIMEOUT=$default_timeout
+
+# 
+create_test_file() {
+
+    if [ "$#" -eq 1 ]
+    then
+	    rm -f "$1"
+	    echo "#!/bin/bash" >> "$1"
+        return 0
+    else
+        echo "Error. Missing the parameter for the test file to create."
+        return 1
+    fi
+}
+
+# Set the timeout.
+# $1: timeout in seconds. A negative value is not allowed. Set 0 to disable the timeout and -1 to reset to default value
+set_timeout() {
+
+    if [ "$#" -eq 1 ]
+    then
+        if [ "$1" -gt 0 ]
+        then
+            export TIMEOUT=$1
+            return 0
+        elif [ "$1" -eq 0 ]
+        then
+            unset TIMEOUT
+            return 0
+        elif [ "$1" -eq -1 ]
+        then
+            export TIMEOUT=$default_timeout
+            return 0
+        else
+            echo "[ERROR] Wrong timeout value. It must be a positive integer, 0 to disable or -1 to reset to default value"
+            return 1
+        fi
+    else
+        echo "Error. Wrong number of parameters. Use timeout timeout_value"
+        echo "   The timeout value is a positive integer. Use '0' to disable the timeout and '-1' to reset to default value"
+        return 1
+    fi
+
+}
+
+# Generate a test that is executed with or without timeout based on the original test
+# $1: Name of the original test
+# $2: File where create the test (full path)
+create_test_with_template() {
+
+    if [ "$#" -eq 2 ]
+    then
+        test_name="$1_with_timeout"
+        {
+            echo "";
+            echo "$test_name() {";
+            echo "  if [ -z \"\$TIMEOUT\" ]";
+            echo "  then";
+            echo "    $1";
+            echo "  else";
+            echo "    run_with_timeout $1"
+            echo "  fi"
+            echo "}"
+            echo ""
+        } >> "$2"
+        echo "$test_name"
+    else
+        echo "Error. Missing parameters:"
+        echo "   Name of the original test"
+        echo "   File where create the test (full path)"
+        return 1
+    fi
+
+}
+
+# Execute a function setting a timeout. If the timeout happens then the execution of the function is killed and a message is displayed
+# $1: name of the fucntion to execute
+run_with_timeout() {
+
+    cmd="$1"
+    timeout="$TIMEOUT"
+    
+    ( 
+        eval "$cmd" &
+        child=$!
+        trap -- "" SIGTERM 
+        (
+                sleep $timeout
+                # Only kills and displays message if the function is still running
+                # shellcheck disable=SC2009
+                if [ "$(ps -p $child | grep -cv PID )" -ne 0 ]
+                then 
+                    echo "[ERROR] $1 timeout. Passed $timeout seconds"
+                    kill_process_and_subprocess $child
+                fi
+        ) &     
+        wait $child
+    )
+
+}
+
+# Kill the process and all the subprocesses that it can open
+# $1: PID of the process to kill
+kill_process_and_subprocess() {
+
+    for subprocess in $(pgrep -P "$1")
+    do
+        # Kill the subprocess
+        kill_process_and_subprocess "$subprocess"
+    done
+    # Kill execution
+    kill "$1" 2> /dev/null 
+
+}

--- a/src/utilities/timeout.inc
+++ b/src/utilities/timeout.inc
@@ -20,7 +20,7 @@ create_test_file() {
 }
 
 # Set the timeout.
-# $1: timeout in seconds. A negative value is not allowed. Set 0 to disable the timeout and -1 to reset to default value
+# $1: timeout in seconds. It must be a number greater than 0. Set 0 to disable the timeout and -1 to reset to default value
 set_timeout() {
 
     if [ "$#" -eq 1 ]
@@ -38,12 +38,12 @@ set_timeout() {
             export TIMEOUT=$default_timeout
             return 0
         else
-            echo "[ERROR] Wrong timeout value. It must be a positive integer, 0 to disable or -1 to reset to default value"
+            echo "[ERROR] Wrong timeout value. The timeout value is a number of seconds greater than 0. Use '0' to disable the timeout and '-1' to reset to default value"
             return 1
         fi
     else
         echo "Error. Wrong number of parameters. Use timeout timeout_value"
-        echo "   The timeout value is a positive integer. Use '0' to disable the timeout and '-1' to reset to default value"
+        echo "   The timeout value is a number of seconds greater than 0. Use '0' to disable the timeout and '-1' to reset to default value"
         return 1
     fi
 
@@ -80,7 +80,7 @@ create_test_with_template() {
 }
 
 # Execute a function setting a timeout. If the timeout happens then the execution of the function is killed and a message is displayed
-# $1: name of the fucntion to execute
+# $1: name of the function to execute
 run_with_timeout() {
 
     cmd="$1"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,3 +11,4 @@ test:
 	git clone --depth 1 https://github.com/kward/shunit2 ../.shunit2 && cd ../.shunit2 && git checkout abb3ab2fef8c549933e378ae3d12127dfc748e73
 	./workspace_hook_tests.sh
 	./tests.sh
+	./timeout-tests.sh

--- a/tests/test_resources/test_timeout/Jenkinsfile
+++ b/tests/test_resources/test_timeout/Jenkinsfile
@@ -1,0 +1,7 @@
+stage('Read Evergreen YAML') {
+    node {
+        while(true) {
+            // it hangs
+        }
+    }
+}

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -16,6 +16,15 @@ oneTimeSetUp() {
   downloaded_cwp_jar=$(download_cwp "$working_directory")
 }
 
+setUp() {
+if [[ ${_shunit_test_} == *"using_cwp_docker_image"* ]]
+  then
+    set_timeout 900
+  else
+    set_timeout -1
+  fi
+}
+
 test_with_tag() {
   jfr_tag=$(execute_cwp_jar_and_generate_docker_image "$working_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/test_with_tag/packager-config.yml" "$jenkinsfile_runner_tag" | grep 'Successfully tagged')
   execution_should_success "$?" "$jfr_tag" "$jenkinsfile_runner_tag"
@@ -46,10 +55,13 @@ test_with_default_tag() {
 }
 
 test_download_cwp_version() {
-  default_cwp_jar=$(download_cwp "$working_directory")
+  test_download_working_directory="$working_directory/test_download_cwp_version"
+  rm -rf "$test_download_working_directory"
+  mkdir "$test_download_working_directory"
+  default_cwp_jar=$(download_cwp "$test_download_working_directory")
   execution_should_success "$?" "$default_cwp_jar" "cwp-cli-$DEFAULT_CWP_VERSION.jar"
 
-  another_cwp_jar=$(download_cwp "$working_directory" "1.3")
+  another_cwp_jar=$(download_cwp "$test_download_working_directory" "1.3")
   execution_should_success "$?" "$another_cwp_jar" "cwp-cli-1.3.jar"
 }
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -17,7 +17,7 @@ oneTimeSetUp() {
 }
 
 setUp() {
-if [[ ${_shunit_test_} == *"using_cwp_docker_image"* ]]
+  if [[ ${_shunit_test_} == *"using_cwp_docker_image"* ]]
   then
     set_timeout 900
   else

--- a/tests/timeout-tests.sh
+++ b/tests/timeout-tests.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+current_directory=$(pwd)
+test_framework_directory="$current_directory/.."
+working_directory="$current_directory/.testing"
+
+version="256.0-test"
+jenkinsfile_runner_tag="jenkins-experimental/jenkinsfile-runner-test-image"
+
+. $test_framework_directory/init-jfr-test-framework.inc
+
+setUp() {
+  downloaded_cwp_jar=$(download_cwp "$working_directory")
+  execute_cwp_jar_and_generate_docker_image "$working_directory" "$downloaded_cwp_jar" "$version" "$current_directory/test_resources/test_with_tag/packager-config.yml" "$jenkinsfile_runner_tag"  | grep 'Successfully tagged'
+}
+
+test_timeout() {
+  run_jfr_docker_image "$jenkinsfile_runner_tag" "$current_directory/test_resources/test_timeout/Jenkinsfile"
+  jenkinsfile_execution_should_succed "$?"
+}
+
+# Prepare docker image
+setUp
+
+# Set timeout value to 10 seconds
+set_timeout 10
+
+# Eval the timeout
+set +e
+result=$(eval run_with_timeout "test_timeout" | grep "[ERROR]*timeout")
+set -e
+
+# Print result
+if [[ "$result" != *"[ERROR] test_timeout timeout. Passed 10 seconds"* ]]
+then
+  echo "test FAIL: test_timeout should timeout"
+  echo "1 test executed"
+else
+  echo "test OK"
+  echo "1 test executed"
+fi

--- a/tests/workspace_hook_tests.sh
+++ b/tests/workspace_hook_tests.sh
@@ -6,7 +6,6 @@ test_framework_directory="$current_directory/.."
 testing_directory="$current_directory/.testing"
 working_directory="$testing_directory/workspace-test"
 test_file="test.txt"
-sh_unit_directory="$testing_directory/shunit2"
 
 . $test_framework_directory/init-jfr-test-framework.inc
 
@@ -25,7 +24,7 @@ oneTimeTearDown() {
 
 test_workspace_exists() {
   # Passing another directory to check if exist so we do not use the WORKSPACE environment variable
-  workspace_exists "$sh_unit_directory"
+  workspace_exists "$test_framework_directory"
 }
 
 test_workspace_does_not_exist() {
@@ -48,4 +47,4 @@ test_file_does_not_contains_text() {
   file_does_not_contains_text "unexpected text" "$test_file"
 }
 
-. $sh_unit_directory/shunit2
+init_framework


### PR DESCRIPTION
See [JENKINS-54391](https://issues.jenkins-ci.org/browse/JENKINS-54391)

As part of the initial test framework, this PR intends to add the support to execute each test with a timeout.