### PR TITLE
Fix commit hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ init:
 	# TODO So far, the released tags do not contains all the macros and functions that
 	# master branch does (assertContains, e.g.). Once a new version containing all 
 	# the functionalyty is released we should clone using --branch
-	git clone --depth 1 https://github.com/kward/shunit2 .shunit2 && cd .shunit2 && git checkout abb3ab2fef8c549933e378ae3d12127dfc748e73
+	git clone https://github.com/kward/shunit2 .shunit2 && cd .shunit2 && git checkout abb3ab2fef8c549933e378ae3d12127dfc748e73
 
 test:
 	$(MAKE) -C tests

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,6 +8,6 @@ test:
 	# TODO So far, the released tags do not contains all the macros and functions that
 	# master branch does (assertContains, e.g.). Once a new version containing all 
 	# the functionalyty is released we should clone using --branch
-	git clone --depth 1 https://github.com/kward/shunit2 ../.shunit2 && cd ../.shunit2 && git checkout abb3ab2fef8c549933e378ae3d12127dfc748e73
+	git clone https://github.com/kward/shunit2 ../.shunit2 && cd ../.shunit2 && git checkout abb3ab2fef8c549933e378ae3d12127dfc748e73
 	./workspace_hook_tests.sh
 	./tests.sh


### PR DESCRIPTION
The commit in shUnit2 repository on which the test framework relies is not available if we use the `--depth 1` option. Fixing it